### PR TITLE
Signal CEA-608/708 in DASH and force 2-character language for HLS captions

### DIFF
--- a/include/packager/mpd_params.h
+++ b/include/packager/mpd_params.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include <packager/hls_params.h>
+
 namespace shaka {
 
 /// DASH MPD related parameters.
@@ -102,6 +104,8 @@ struct MpdParams {
   /// and is greatly influnced by the player.
   /// This parameter is required by DASH-IF Low Latency standards.
   double target_latency_seconds = 1;
+  /// CEA-608 / CEA-708 captions.
+  std::vector<CeaCaption> closed_captions;
 };
 
 }  // namespace shaka

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -589,6 +589,7 @@ std::optional<PackagingParams> GetPackagingParams() {
                << absl::GetFlag(FLAGS_closed_captions);
     return std::nullopt;
   }
+  mpd_params.closed_captions = hls_params.closed_captions;
 
   TestParams& test_params = packaging_params.test_params;
   test_params.dump_stream_info = absl::GetFlag(FLAGS_dump_stream_info);

--- a/packager/hls/base/master_playlist.cc
+++ b/packager/hls/base/master_playlist.cc
@@ -22,6 +22,7 @@
 #include <packager/hls/base/media_playlist.h>
 #include <packager/hls/base/tag.h>
 #include <packager/macros/logging.h>
+#include <packager/media/base/language_utils.h>
 #include <packager/version/version.h>
 
 #include "packager/kv_pairs/kv_pairs.h"
@@ -451,7 +452,7 @@ void BuildCeaMediaTag(const CeaCaption& caption, std::string* out) {
   tag.AddQuotedString("GROUP-ID", "CC");
   tag.AddQuotedString("NAME", caption.name);
   if (!caption.language.empty()) {
-    tag.AddQuotedString("LANGUAGE", caption.language);
+    tag.AddQuotedString("LANGUAGE", LanguageToShortestForm(caption.language));
   }
   if (caption.is_default)
     tag.AddString("DEFAULT", "YES");

--- a/packager/mpd/base/mpd_notifier.h
+++ b/packager/mpd/base/mpd_notifier.h
@@ -162,6 +162,8 @@ class MpdNotifier {
     return mpd_options_.mpd_params.use_segment_list;
   }
 
+  const MpdOptions& mpd_options() const { return mpd_options_; }
+
  private:
   const MpdOptions mpd_options_;
 

--- a/packager/mpd/base/simple_mpd_notifier.cc
+++ b/packager/mpd/base/simple_mpd_notifier.cc
@@ -15,6 +15,7 @@
 #include <packager/mpd/base/mpd_utils.h>
 #include <packager/mpd/base/period.h>
 #include <packager/mpd/base/representation.h>
+#include <packager/media/base/language_utils.h>
 
 namespace shaka {
 
@@ -52,8 +53,10 @@ bool SimpleMpdNotifier::NotifyNewContainer(const MediaInfo& media_info,
   AdaptationSet* adaptation_set = period->GetOrCreateAdaptationSet(
       media_info, content_protection_in_adaptation_set_);
   DCHECK(adaptation_set);
-  if (!adaptation_set->has_id())
+  if (!adaptation_set->has_id()) {
     adaptation_set->set_id(next_adaptation_set_id_++);
+    AddClosedCaptionsToAdaptationSet(media_info, adaptation_set);
+  }
   Representation* representation =
       adaptation_set->AddRepresentation(adjusted_media_info);
   if (!representation)
@@ -157,6 +160,7 @@ bool SimpleMpdNotifier::NotifyCueEvent(uint32_t container_id,
   DCHECK(adaptation_set);
   if (!adaptation_set->has_id()) {
     adaptation_set->set_id(original_adaptation_set->id());
+    AddClosedCaptionsToAdaptationSet(media_info, adaptation_set);
   } else {
     DCHECK_EQ(adaptation_set->id(), original_adaptation_set->id());
   }
@@ -221,6 +225,42 @@ bool SimpleMpdNotifier::NotifyMediaInfoUpdate(uint32_t container_id,
 bool SimpleMpdNotifier::Flush() {
   absl::MutexLock lock(&lock_);
   return WriteMpdToFile(output_path_, mpd_builder_.get());
+}
+
+void SimpleMpdNotifier::AddClosedCaptionsToAdaptationSet(
+    const MediaInfo& media_info,
+    AdaptationSet* adaptation_set) {
+  if (!adaptation_set->IsVideo() ||
+      mpd_options().mpd_params.closed_captions.empty()) {
+    return;
+  }
+  if (media_info.has_video_info() &&
+      media_info.video_info().has_playback_rate()) {
+    return;
+  }
+  std::string cea608_value;
+  std::string cea708_value;
+  for (const auto& caption : mpd_options().mpd_params.closed_captions) {
+    std::string channel = caption.channel;
+    std::string language = LanguageToISO_639_2(caption.language);
+    if (channel.find("CC") == 0) {
+      if (!cea608_value.empty())
+        cea608_value += ";";
+      cea608_value += channel + "=" + language;
+    } else if (channel.find("SERVICE") == 0) {
+      if (!cea708_value.empty())
+        cea708_value += ";";
+      cea708_value += channel.substr(7) + "=lang:" + language;
+    }
+  }
+  if (!cea608_value.empty()) {
+    adaptation_set->AddAccessibility("urn:scte:dash:cc:cea-608:2015",
+                                     cea608_value);
+  }
+  if (!cea708_value.empty()) {
+    adaptation_set->AddAccessibility("urn:scte:dash:cc:cea-708:2015",
+                                     cea708_value);
+  }
 }
 
 }  // namespace shaka

--- a/packager/mpd/base/simple_mpd_notifier.h
+++ b/packager/mpd/base/simple_mpd_notifier.h
@@ -61,6 +61,9 @@ class SimpleMpdNotifier : public MpdNotifier {
   /// @}
 
  private:
+  void AddClosedCaptionsToAdaptationSet(const MediaInfo& media_info,
+                                        AdaptationSet* adaptation_set);
+
   SimpleMpdNotifier(const SimpleMpdNotifier&) = delete;
   SimpleMpdNotifier& operator=(const SimpleMpdNotifier&) = delete;
 


### PR DESCRIPTION
This change adds signaling for CEA-608 and CEA-708 captions in the DASH manifest (MPD) using the SCTE URIs. It reuses the existing `--closed_captions` flag. It also ensures that language codes in the HLS master playlist for CLOSED-CAPTIONS are forced to their shortest form (typically 2 characters) for consistency with audio tracks. In the DASH manifest, it uses 3-character ISO 639-2 codes as requested. Trick play streams are excluded from this signaling in DASH.

---
*PR created automatically by Jules for task [18180683912510901004](https://jules.google.com/task/18180683912510901004) started by @xavierlaffargue*