### PR TITLE
Unify Closed Captions Signaling and Add DASH support

### DIFF
--- a/include/packager/cea_caption.h
+++ b/include/packager/cea_caption.h
@@ -1,0 +1,30 @@
+// Copyright 2024 Google LLC. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#ifndef PACKAGER_PUBLIC_CEA_CAPTION_H_
+#define PACKAGER_PUBLIC_CEA_CAPTION_H_
+
+#include <string>
+
+namespace shaka {
+
+/// CEA caption description.
+struct CeaCaption {
+  /// The display name of the caption.
+  std::string name;
+  /// The language of the caption.
+  std::string language;
+  /// The channel of the caption, e.g. "CC1", "SERVICE2".
+  std::string channel;
+  /// True if this is the default caption.
+  bool is_default = false;
+  /// True if this caption should be autoselected.
+  bool autoselect = true;
+};
+
+}  // namespace shaka
+
+#endif  // PACKAGER_PUBLIC_CEA_CAPTION_H_

--- a/include/packager/hls_params.h
+++ b/include/packager/hls_params.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <vector>
 
+#include <packager/cea_caption.h>
+
 namespace shaka {
 
 /// Defines the EXT-X-PLAYLIST-TYPE in the HLS specification. For
@@ -20,20 +22,6 @@ enum class HlsPlaylistType {
   kVod,
   kEvent,
   kLive,
-};
-
-// CEA caption description.
-struct CeaCaption {
-  // The display name of the caption.
-  std::string name;
-  // The language of the caption.
-  std::string language;
-  // The channel of the caption, e.g. "CC1", "SERVICE2".
-  std::string channel;
-  // True if this is the default caption.
-  bool is_default = false;
-  // True if this caption should be autoselected.
-  bool autoselect = true;
 };
 
 /// HLS related parameters.

--- a/include/packager/mpd_params.h
+++ b/include/packager/mpd_params.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include <packager/cea_caption.h>
+
 namespace shaka {
 
 /// DASH MPD related parameters.
@@ -102,6 +104,8 @@ struct MpdParams {
   /// and is greatly influnced by the player.
   /// This parameter is required by DASH-IF Low Latency standards.
   double target_latency_seconds = 1;
+  /// CEA-608 / CEA-708 captions.
+  std::vector<CeaCaption> closed_captions;
 };
 
 }  // namespace shaka

--- a/include/packager/packager.h
+++ b/include/packager/packager.h
@@ -16,6 +16,7 @@
 #include <packager/ad_cue_generator_params.h>
 #include <packager/buffer_callback_params.h>
 #include <packager/chunking_params.h>
+#include <packager/cea_caption.h>
 #include <packager/crypto_params.h>
 #include <packager/export.h>
 #include <packager/file.h>
@@ -76,6 +77,9 @@ struct PackagingParams {
 
   /// Buffer callback params.
   BufferCallbackParams buffer_callback_params;
+
+  /// CEA-608 / CEA-708 captions.
+  std::vector<CeaCaption> closed_captions;
 
   // Parameters for testing. Do not use in production.
   TestParams test_params;

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -584,7 +584,7 @@ std::optional<PackagingParams> GetPackagingParams() {
       absl::GetFlag(FLAGS_per_playlist_target_duration);
 
   if (!ParseClosedCaptions(absl::GetFlag(FLAGS_closed_captions),
-                           &hls_params.closed_captions)) {
+                           &packaging_params.closed_captions)) {
     LOG(ERROR) << "Failed to parse --closed_captions "
                << absl::GetFlag(FLAGS_closed_captions);
     return std::nullopt;

--- a/packager/mpd/base/mock_mpd_builder.h
+++ b/packager/mpd/base/mock_mpd_builder.h
@@ -61,6 +61,8 @@ class MockAdaptationSet : public AdaptationSet {
                void(const AdaptationSet* adaptation_set));
   MOCK_METHOD1(AddTrickPlayReference,
                void(const AdaptationSet* adaptation_set));
+  MOCK_METHOD2(AddAccessibility,
+               void(const std::string& scheme, const std::string& value));
 
  private:
   // Only for constructing the super class. Not used for testing.

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -8,6 +8,7 @@
 
 #include <absl/log/check.h>
 #include <absl/log/log.h>
+#include <absl/strings/match.h>
 
 #include <packager/mpd/base/adaptation_set.h>
 #include <packager/mpd/base/mpd_options.h>
@@ -313,6 +314,22 @@ bool Period::SetNewAdaptationSetAttributes(
       media_info.has_protected_content()) {
     new_adaptation_set->set_protected_content(media_info);
     AddContentProtectionElements(media_info, new_adaptation_set);
+  }
+
+  if (media_info.has_video_info() &&
+      !media_info.video_info().has_playback_rate()) {
+    for (const auto& caption : mpd_options_.mpd_params.closed_captions) {
+      if (absl::StartsWith(caption.channel, "CC")) {
+        new_adaptation_set->AddAccessibility(
+            "urn:scte:dash:cc:cea-608:2015",
+            caption.channel + "=" + caption.language);
+      } else if (absl::StartsWith(caption.channel, "SERVICE")) {
+        std::string service_number = caption.channel.substr(7);
+        new_adaptation_set->AddAccessibility(
+            "urn:scte:dash:cc:cea-708:2015",
+            service_number + "=lang:" + caption.language);
+      }
+    }
   }
 
   return true;

--- a/packager/mpd/base/period_unittest.cc
+++ b/packager/mpd/base/period_unittest.cc
@@ -410,6 +410,66 @@ TEST_F(PeriodTest, TrickPlayWithNoMatchingAdaptationSet) {
   ASSERT_TRUE(!testable_period_.trickplay_cache().empty());
 }
 
+TEST_F(PeriodTest, ClosedCaptions) {
+  mpd_options_.mpd_params.closed_captions.push_back(
+      {"name1", "eng", "CC1", true, true});
+  mpd_options_.mpd_params.closed_captions.push_back(
+      {"name2", "fra", "SERVICE1", false, true});
+
+  const char kVideoMediaInfo[] =
+      "video_info {\n"
+      "  codec: 'avc1'\n"
+      "  width: 1280\n"
+      "  height: 720\n"
+      "  time_scale: 10\n"
+      "  frame_duration: 10\n"
+      "  pixel_width: 1\n"
+      "  pixel_height: 1\n"
+      "}\n"
+      "container_type: 1\n";
+
+  EXPECT_CALL(testable_period_, NewAdaptationSet(_, _, _))
+      .WillOnce(Return(ByMove(std::move(default_adaptation_set_))));
+
+  EXPECT_CALL(*default_adaptation_set_ptr_,
+              AddAccessibility("urn:scte:dash:cc:cea-608:2015", "CC1=eng"));
+  EXPECT_CALL(*default_adaptation_set_ptr_,
+              AddAccessibility("urn:scte:dash:cc:cea-708:2015", "1=lang:fra"));
+
+  ASSERT_EQ(default_adaptation_set_ptr_,
+            testable_period_.GetOrCreateAdaptationSet(
+                ConvertToMediaInfo(kVideoMediaInfo),
+                content_protection_in_adaptation_set_));
+}
+
+TEST_F(PeriodTest, NoClosedCaptionsForTrickPlay) {
+  mpd_options_.mpd_params.closed_captions.push_back(
+      {"name1", "eng", "CC1", true, true});
+
+  const char kTrickPlayMediaInfo[] =
+      "video_info {\n"
+      "  codec: 'avc1'\n"
+      "  width: 1280\n"
+      "  height: 720\n"
+      "  time_scale: 10\n"
+      "  frame_duration: 10\n"
+      "  pixel_width: 1\n"
+      "  pixel_height: 1\n"
+      "  playback_rate: 10\n"
+      "}\n"
+      "container_type: 1\n";
+
+  EXPECT_CALL(testable_period_, NewAdaptationSet(_, _, _))
+      .WillOnce(Return(ByMove(std::move(default_adaptation_set_))));
+
+  EXPECT_CALL(*default_adaptation_set_ptr_, AddAccessibility(_, _)).Times(0);
+
+  ASSERT_EQ(default_adaptation_set_ptr_,
+            testable_period_.GetOrCreateAdaptationSet(
+                ConvertToMediaInfo(kTrickPlayMediaInfo),
+                content_protection_in_adaptation_set_));
+}
+
 // Don't put different audio languages or codecs in the same AdaptationSet.
 TEST_F(PeriodTest, SplitAdaptationSetsByLanguageAndCodec) {
   const char kAacEnglishAudioContent[] =

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -876,6 +876,16 @@ Status Packager::Initialize(
   hls_params.is_independent_segments =
       packaging_params.chunking_params.segment_sap_aligned;
 
+  for (const auto& caption : packaging_params.closed_captions) {
+    CeaCaption dash_caption = caption;
+    dash_caption.language = LanguageToISO_639_2(caption.language);
+    mpd_params.closed_captions.push_back(dash_caption);
+
+    CeaCaption hls_caption = caption;
+    hls_caption.language = LanguageToShortestForm(caption.language);
+    hls_params.closed_captions.push_back(hls_caption);
+  }
+
   if (!mpd_params.mpd_output.empty()) {
     const bool on_demand_dash_profile =
         stream_descriptors.begin()->segment_template.empty();


### PR DESCRIPTION
This change unifies the handling of CEA closed captions across HLS and DASH. It moves the `closed_captions` configuration to a central location in `PackagingParams` to avoid duplication. 

For DASH, it now signals CEA-608 and CEA-708 via `<Accessibility>` elements in video AdaptationSets (excluding trickplays), using standard schemes and specific value formats (CCn=lang and n=lang:lang). 

Language codes are automatically converted to their required formats: 3 characters for DASH and shortest form (usually 2 characters) for HLS. 

A new header `include/packager/cea_caption.h` was introduced to prevent circular dependencies between public headers.

---
*PR created automatically by Jules for task [3827051386065875993](https://jules.google.com/task/3827051386065875993) started by @xavierlaffargue*